### PR TITLE
remove dependency on HandleFriendRequestInteractor

### DIFF
--- a/src/main/java/app/usecase/match_interaction/MatchInteractionInteractor.java
+++ b/src/main/java/app/usecase/match_interaction/MatchInteractionInteractor.java
@@ -68,8 +68,11 @@ public class MatchInteractionInteractor implements MatchInteractionInputBoundary
 
         // Has the current user already sent a request to matchedUser?
         boolean alreadyOutgoing =
-                userSession.getOutgoingMatches().contains(matchedUser) ||
-                        matchDataAccessObject.getOutgoingFriendRequest(currentUser).contains(matchedUser);
+                userSession.getOutgoingMatches().contains(matchedUser)
+                        || matchDataAccessObject
+                        .getOutgoingFriendRequest(currentUser)
+                        .contains(matchedUser);
+
 
         if (alreadyOutgoing) {
             presenter.presentMatchInteractionResult(new MatchInteractionOutputData(
@@ -80,8 +83,10 @@ public class MatchInteractionInteractor implements MatchInteractionInputBoundary
 
         // Did matchedUser already send a request to currentUser? => mutual connect
         boolean mutualConnect =
-                userSession.getIncomingMatches().contains(matchedUser) ||
-                        matchDataAccessObject.getOutgoingFriendRequest(matchedUser).contains(currentUser);
+                userSession.getIncomingMatches().contains(matchedUser)
+                        || matchDataAccessObject
+                        .getOutgoingFriendRequest(matchedUser)
+                        .contains(currentUser);
 
         if (mutualConnect) {
             // Clean up pending requests on both sides

--- a/src/main/java/app/usecase/match_interaction/MatchInteractionInteractor.java
+++ b/src/main/java/app/usecase/match_interaction/MatchInteractionInteractor.java
@@ -48,21 +48,30 @@ public class MatchInteractionInteractor implements MatchInteractionInputBoundary
 
         // Basic guards
         if (currentUser == null || matchedUser == null) {
-            presenter.presentMatchInteractionResult(new MatchInteractionOutputData(
-                    false, false, matchedUser == null ? "" : matchedUser.getName(),
-                    "Cannot connect right now."));
+            presenter.presentMatchInteractionResult(
+                    new MatchInteractionOutputData(
+                            false,
+                            false,
+                            matchedUser == null ? "" : matchedUser.getName(),
+                            "Cannot connect right now."));
             return;
         }
         if (currentUser.equals(matchedUser)) {
-            presenter.presentMatchInteractionResult(new MatchInteractionOutputData(
-                    false, false, matchedUser.getName(),
-                    "You can't connect with yourself."));
+            presenter.presentMatchInteractionResult(
+                    new MatchInteractionOutputData(
+                            false,
+                            false,
+                            matchedUser.getName(),
+                            "You can't connect with yourself."));
             return;
         }
         if (currentUser.getFriendList().contains(matchedUser)) {
-            presenter.presentMatchInteractionResult(new MatchInteractionOutputData(
-                    true, true, matchedUser.getName(),
-                    "You’re already friends with " + matchedUser.getName()));
+            presenter.presentMatchInteractionResult(
+                    new MatchInteractionOutputData(
+                            true,
+                            true,
+                            matchedUser.getName(),
+                            "You’re already friends with " + matchedUser.getName()));
             return;
         }
 
@@ -70,14 +79,16 @@ public class MatchInteractionInteractor implements MatchInteractionInputBoundary
         boolean alreadyOutgoing =
                 userSession.getOutgoingMatches().contains(matchedUser)
                         || matchDataAccessObject
-                        .getOutgoingFriendRequest(currentUser)
-                        .contains(matchedUser);
-
+                                .getOutgoingFriendRequest(currentUser)
+                                .contains(matchedUser);
 
         if (alreadyOutgoing) {
-            presenter.presentMatchInteractionResult(new MatchInteractionOutputData(
-                    true, false, matchedUser.getName(),
-                    "You’ve already sent a request to " + matchedUser.getName()));
+            presenter.presentMatchInteractionResult(
+                    new MatchInteractionOutputData(
+                            true,
+                            false,
+                            matchedUser.getName(),
+                            "You’ve already sent a request to " + matchedUser.getName()));
             return;
         }
 
@@ -85,8 +96,8 @@ public class MatchInteractionInteractor implements MatchInteractionInputBoundary
         boolean mutualConnect =
                 userSession.getIncomingMatches().contains(matchedUser)
                         || matchDataAccessObject
-                        .getOutgoingFriendRequest(matchedUser)
-                        .contains(currentUser);
+                                .getOutgoingFriendRequest(matchedUser)
+                                .contains(currentUser);
 
         if (mutualConnect) {
             // Clean up pending requests on both sides
@@ -99,9 +110,12 @@ public class MatchInteractionInteractor implements MatchInteractionInputBoundary
             // Become friends
             addFriendList.addFriend(currentUser, matchedUser);
 
-            presenter.presentMatchInteractionResult(new MatchInteractionOutputData(
-                    true, true, matchedUser.getName(),
-                    "You are now friends with " + matchedUser.getName()));
+            presenter.presentMatchInteractionResult(
+                    new MatchInteractionOutputData(
+                            true,
+                            true,
+                            matchedUser.getName(),
+                            "You are now friends with " + matchedUser.getName()));
             return;
         }
 
@@ -114,11 +128,13 @@ public class MatchInteractionInteractor implements MatchInteractionInputBoundary
             userSession.getOutgoingMatches().add(matchedUser);
         }
 
-        presenter.presentMatchInteractionResult(new MatchInteractionOutputData(
-                true, false, matchedUser.getName(),
-                "Friend request sent to " + matchedUser.getName()));
+        presenter.presentMatchInteractionResult(
+                new MatchInteractionOutputData(
+                        true,
+                        false,
+                        matchedUser.getName(),
+                        "Friend request sent to " + matchedUser.getName()));
     }
-
 
     /**
      * Called when the current user chooses to skip a matched user. The matched user is removed from

--- a/src/main/java/app/usecase/match_interaction/MatchInteractionInteractor.java
+++ b/src/main/java/app/usecase/match_interaction/MatchInteractionInteractor.java
@@ -13,7 +13,6 @@ import app.usecase.handle_friend_request.HandleFriendRequestInputBoundary;
 public class MatchInteractionInteractor implements MatchInteractionInputBoundary {
 
     private final MatchDataAccessInterface matchDataAccessObject;
-    private final HandleFriendRequestInputBoundary handleFriendRequest;
     private final AddFriendListInputBoundary addFriendList;
     private final MatchInteractionOutputBoundary presenter;
 
@@ -31,7 +30,6 @@ public class MatchInteractionInteractor implements MatchInteractionInputBoundary
             AddFriendListInputBoundary addFriendList,
             MatchInteractionOutputBoundary presenter) {
         this.matchDataAccessObject = matchDataAccessObject;
-        this.handleFriendRequest = handleFriendRequest;
         this.addFriendList = addFriendList;
         this.presenter = presenter;
     }
@@ -48,34 +46,74 @@ public class MatchInteractionInteractor implements MatchInteractionInputBoundary
     public void connect(UserSession userSession, User matchedUser) {
         User currentUser = userSession.getUser();
 
+        // Basic guards
+        if (currentUser == null || matchedUser == null) {
+            presenter.presentMatchInteractionResult(new MatchInteractionOutputData(
+                    false, false, matchedUser == null ? "" : matchedUser.getName(),
+                    "Cannot connect right now."));
+            return;
+        }
+        if (currentUser.equals(matchedUser)) {
+            presenter.presentMatchInteractionResult(new MatchInteractionOutputData(
+                    false, false, matchedUser.getName(),
+                    "You can't connect with yourself."));
+            return;
+        }
+        if (currentUser.getFriendList().contains(matchedUser)) {
+            presenter.presentMatchInteractionResult(new MatchInteractionOutputData(
+                    true, true, matchedUser.getName(),
+                    "You’re already friends with " + matchedUser.getName()));
+            return;
+        }
+
+        // Has the current user already sent a request to matchedUser?
+        boolean alreadyOutgoing =
+                userSession.getOutgoingMatches().contains(matchedUser) ||
+                        matchDataAccessObject.getOutgoingFriendRequest(currentUser).contains(matchedUser);
+
+        if (alreadyOutgoing) {
+            presenter.presentMatchInteractionResult(new MatchInteractionOutputData(
+                    true, false, matchedUser.getName(),
+                    "You’ve already sent a request to " + matchedUser.getName()));
+            return;
+        }
+
+        // Did matchedUser already send a request to currentUser? => mutual connect
         boolean mutualConnect =
-                matchDataAccessObject.getOutgoingFriendRequest(matchedUser).contains(currentUser);
+                userSession.getIncomingMatches().contains(matchedUser) ||
+                        matchDataAccessObject.getOutgoingFriendRequest(matchedUser).contains(currentUser);
 
         if (mutualConnect) {
-            addFriendList.addFriend(currentUser, matchedUser);
+            // Clean up pending requests on both sides
             matchDataAccessObject.getOutgoingFriendRequest(matchedUser).remove(currentUser);
             matchDataAccessObject.getIncomingFriendRequest(currentUser).remove(matchedUser);
 
             userSession.getIncomingMatches().remove(matchedUser);
             userSession.getOutgoingMatches().remove(matchedUser);
 
-            presenter.presentMatchInteractionResult(
-                    new MatchInteractionOutputData(
-                            true,
-                            true,
-                            matchedUser.getName(),
-                            "You are now friends with " + matchedUser.getName()));
-        } else {
-            handleFriendRequest.sendFriendRequest(userSession, matchedUser);
+            // Become friends
+            addFriendList.addFriend(currentUser, matchedUser);
 
-            presenter.presentMatchInteractionResult(
-                    new MatchInteractionOutputData(
-                            true,
-                            false,
-                            matchedUser.getName(),
-                            "Friend request sent to " + matchedUser.getName()));
+            presenter.presentMatchInteractionResult(new MatchInteractionOutputData(
+                    true, true, matchedUser.getName(),
+                    "You are now friends with " + matchedUser.getName()));
+            return;
         }
+
+        // Otherwise: create a fresh friend request (single source of truth)
+        matchDataAccessObject.addOutgoingFriendRequest(currentUser, matchedUser);
+        matchDataAccessObject.addIncomingFriendRequest(matchedUser, currentUser);
+
+        // Update the current user's local session for UI (outgoing list only)
+        if (!userSession.getOutgoingMatches().contains(matchedUser)) {
+            userSession.getOutgoingMatches().add(matchedUser);
+        }
+
+        presenter.presentMatchInteractionResult(new MatchInteractionOutputData(
+                true, false, matchedUser.getName(),
+                "Friend request sent to " + matchedUser.getName()));
     }
+
 
     /**
      * Called when the current user chooses to skip a matched user. The matched user is removed from


### PR DESCRIPTION
- Removed HandleFriendRequestInputBoundary from MatchInteractionInteractor
- Inlined friend request creation and mutual connect logic directly into connect()
- Added guards to prevent duplicate friend requests and self-connections
- Ensured only MatchInteractionPresenter fires for the Connect button

